### PR TITLE
feat: highlight pasteboard items on hover

### DIFF
--- a/Features/ClipboardUI/Package.swift
+++ b/Features/ClipboardUI/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
             targets: ["ClipboardUI"]),
     ],
     dependencies: [
+        .package(name: "Common", path: "../Common"),
         .package(name: "PasteboardProvider", path: "../PasteboardProvider"),
         .package(name: "Localizable", path: "../Localizable"),
         .package(url: "git@github.com:BradAngliss/Swiftux.git", exact: "0.7.0")
@@ -28,7 +29,8 @@ let package = Package(
             dependencies: [
                 "Swiftux",
                 "Localizable",
-                "PasteboardProvider"
+                "PasteboardProvider",
+                "Common"
             ]
         ),
         .testTarget(

--- a/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardItemRowView.swift
+++ b/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardItemRowView.swift
@@ -8,8 +8,10 @@
 import Foundation
 import SwiftUI
 import Localizable
+import Common
 
 struct ClipboardItemRowView: View {
+    @State private var isHovering: Bool = false
     let item: PasteboardItem
 
     var body: some View {
@@ -17,6 +19,10 @@ struct ClipboardItemRowView: View {
             itemRow(
                 item: item
             )
+            .frame(maxHeight: 40)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 1)
+            .hoverBackground(isHovering: $isHovering)
             Divider()
         }
         .padding(.vertical, 2)
@@ -36,7 +42,7 @@ struct ClipboardItemRowView: View {
             HStack {
                 Image(nsImage: NSImage(data: item.displayData)!)
                     .resizable()
-                    .frame(width: 100, height: 100)
+                    .aspectRatio(contentMode: .fit)
                 Spacer()
                 Text(item.availableType.rawValue)
             }

--- a/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardItemRowView.swift
+++ b/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardItemRowView.swift
@@ -19,11 +19,15 @@ struct ClipboardItemRowView: View {
             itemRow(
                 item: item
             )
-            .frame(maxHeight: 40)
-            .padding(.vertical, 4)
-            .padding(.horizontal, 1)
-            .hoverBackground(isHovering: $isHovering)
+                .padding(.horizontal, 8)
+                .frame(maxHeight: 40)
+                .padding(.vertical, 4)
+                .hoverBackground(
+                    hoverColor: .blue,
+                    isHovering: $isHovering
+                )
             Divider()
+                .padding(.horizontal, 8)
         }
         .padding(.vertical, 2)
     }

--- a/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
+++ b/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
@@ -54,25 +54,25 @@ struct ClipboardMenuBarView: View {
         VStack(spacing: 4) {
             HStack {
                 Text(Localizable.stringFor(key: "MenuBarExtra_Refresh_Title"))
-                    .onTapGesture {
-                        store.dispatch(.refreshPasteboardItems)
-                    }
                 Spacer()
             }
             .frame(maxWidth: .infinity)
             .hoverBackground()
+            .onTapGesture {
+                store.dispatch(.refreshPasteboardItems)
+            }
             
             HStack {
                 Text(Localizable.stringFor(key: "MenuBarExtra_Quit_Title"))
-                    .onTapGesture {
-                        NSApplication.shared.terminate(nil)
-                }
                 .keyboardShortcut("q")
                 Spacer()
             }
             .frame(maxWidth: .infinity)
             .hoverBackground()
             .padding(.bottom, 8)
+            .onTapGesture {
+                NSApplication.shared.terminate(nil)
+            }
         }
     }
 }

--- a/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
+++ b/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import Localizable
+import Common
 
 struct ClipboardMenuBarView: View {
     @EnvironmentObject private var store: ClipboardUIStore
@@ -50,17 +51,27 @@ struct ClipboardMenuBarView: View {
     }
 
     private func footer() -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(Localizable.stringFor(key: "MenuBarExtra_Refresh_Title"))
-                .onTapGesture {
-                    store.dispatch(.refreshPasteboardItems)
-                }
-            
-            Text(Localizable.stringFor(key: "MenuBarExtra_Quit_Title"))
-                .onTapGesture {
-                    NSApplication.shared.terminate(nil)
+        VStack(spacing: 4) {
+            HStack {
+                Text(Localizable.stringFor(key: "MenuBarExtra_Refresh_Title"))
+                    .onTapGesture {
+                        store.dispatch(.refreshPasteboardItems)
+                    }
+                Spacer()
             }
-            .keyboardShortcut("q")
+            .frame(maxWidth: .infinity)
+            .hoverBackground()
+            
+            HStack {
+                Text(Localizable.stringFor(key: "MenuBarExtra_Quit_Title"))
+                    .onTapGesture {
+                        NSApplication.shared.terminate(nil)
+                }
+                .keyboardShortcut("q")
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .hoverBackground()
             .padding(.bottom, 8)
         }
     }

--- a/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
+++ b/Features/ClipboardUI/Sources/ClipboardUI/Views/ClipboardMenuBarView.swift
@@ -36,7 +36,6 @@ struct ClipboardMenuBarView: View {
                             }
                     }
                 }
-                .padding(.horizontal, 8)
             }
             Spacer()
             Divider()

--- a/Packages/Common/.gitignore
+++ b/Packages/Common/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/Common/Package.swift
+++ b/Packages/Common/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Common",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Common",
+            targets: ["Common"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Common"),
+        .testTarget(
+            name: "CommonTests",
+            dependencies: ["Common"]),
+    ]
+)

--- a/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
+++ b/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
@@ -1,0 +1,29 @@
+//
+//  ClipHistoryApp.swift
+//  Common
+//
+//  Created by Brad Angliss on 29/09/2024.
+//
+
+import SwiftUI
+
+public extension View {
+    func hoverBackground(
+        isHovering: Binding<Bool>
+    ) -> some View {
+        self.modifier(HoverBackgroundViewModifier(isHovering: isHovering.wrappedValue))
+    }
+}
+
+private struct HoverBackgroundViewModifier: ViewModifier {
+    @State public var isHovering: Bool
+    
+    func body(content: Content) -> some View {
+        content
+            .background(isHovering ? .gray : .clear)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .onHover(perform: { hovering in
+                isHovering = hovering
+            })
+    }
+}

--- a/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
+++ b/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
@@ -9,18 +9,23 @@ import SwiftUI
 
 public extension View {
     func hoverBackground(
+        hoverColor: Color = .gray,
         isHovering: Binding<Bool> = .constant(false)
     ) -> some View {
-        self.modifier(HoverBackgroundViewModifier(isHovering: isHovering.wrappedValue))
+        self.modifier(HoverBackgroundViewModifier(
+            hoverColor: hoverColor,
+            isHovering: isHovering.wrappedValue
+        ))
     }
 }
 
 private struct HoverBackgroundViewModifier: ViewModifier {
+    let hoverColor: Color
     @State public var isHovering: Bool
     
     func body(content: Content) -> some View {
         content
-            .background(isHovering ? .gray : .clear)
+            .background(isHovering ? hoverColor : .clear)
             .clipShape(RoundedRectangle(cornerRadius: 5))
             .onHover(perform: { hovering in
                 isHovering = hovering

--- a/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
+++ b/Packages/Common/Sources/Common/ViewModifiers/HoverBackground.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 public extension View {
     func hoverBackground(
-        isHovering: Binding<Bool>
+        isHovering: Binding<Bool> = .constant(false)
     ) -> some View {
         self.modifier(HoverBackgroundViewModifier(isHovering: isHovering.wrappedValue))
     }

--- a/Packages/Common/Tests/CommonTests/CommonTests.swift
+++ b/Packages/Common/Tests/CommonTests/CommonTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Common
+
+final class CommonTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}


### PR DESCRIPTION
- Create new common package
- Add hoverBackground to Common with binding to allow for external actions
- Add .hoverBackground view modifier to pasteboard list items and Refresh and Quit buttons